### PR TITLE
[MO] Add modeling section with decision tree classifier

### DIFF
--- a/data_mining_project.ipynb
+++ b/data_mining_project.ipynb
@@ -64,7 +64,7 @@
         "- Lessons that could be shared with Wikimedia communities and policymakers incase of encouraging locals to contribute.\n",
         "\n",
         "### Data Mining Goals\n",
-        "- Create a prediction model that can determine the most likely country of origin for each Wikipedia edit made to Zambian pages, using details like the user’s IP address (for anonymous edits), profile information, and the timing of edits.\n",
+        "- Create a prediction model that can determine the most likely country of origin for each Wikipedia edit made to Zambian pages, using details like the user\u2019s IP address (for anonymous edits), profile information, and the timing of edits.\n",
         "\n",
         "- Analyze and visualize the data to show clear summaries of how contributions are distributed by country.\n",
         "\n",
@@ -509,7 +509,7 @@
     {
       "cell_type": "code",
       "source": [
-        "# [DU] Lawrence — Dataset Info and Descriptive Statistics\n",
+        "# [DU] Lawrence \u2014 Dataset Info and Descriptive Statistics\n",
         "\n",
         "# Show dataset structure\n",
         "df.info()\n",
@@ -1289,7 +1289,7 @@
     {
       "cell_type": "code",
       "source": [
-        " # Drop the empty 'contributor_ip' and ‘contributor_id’ columns\n",
+        " # Drop the empty 'contributor_ip' and \u2018contributor_id\u2019 columns\n",
         " df.drop(columns=['contributor_ip'], inplace=True)\n",
         " df.drop(columns=['contributor_id'], inplace=True)\n",
         " # Fill missing values in the 'comment' column with an empty string\n",
@@ -1458,7 +1458,7 @@
             "                                              comment\n",
             "6                 Robot: Adding [[African countries]]\n",
             "9   robot  Adding: am, az, bs, el, fa, ilo, ka, ku...\n",
-            "10                       robot  Adding: [[vo:Sambän]]\n",
+            "10                       robot  Adding: [[vo:Samb\u00e4n]]\n",
             "11       robot  Adding: [[ast:Zambia]], [[qu:Sambya]]\n",
             "12                   robot  Modifying: [[qu:Sambiya]]\n"
           ]
@@ -1660,6 +1660,41 @@
             "New 'page' columns: ['page_id', 'page_2021 Zambian general election', 'page_COVID-19 pandemic in Zambia', 'page_Central Province, Zambia', 'page_Eastern Province, Zambia', 'page_First Lady of Zambia', 'page_Flag of Zambia', 'page_Football Association of Zambia', 'page_List of Presidents of Zambia', 'page_List of Speakers of the National Assembly of Zambia', 'page_List of cities and towns in Zambia', 'page_List of presidents of Zambia', 'page_List of rivers of Zambia', 'page_List of rulers of Zambia', 'page_Livingstone, Zambia', 'page_National Assembly (Zambia)', 'page_National Assembly of Zambia', 'page_North-Western Province, Zambia', 'page_Northern Province, Zambia', 'page_Patriotic Front (Zambia)', 'page_President of Zambia', 'page_Prime Minister of Zambia', 'page_Provinces of Zambia', 'page_Republic of Zambia', 'page_Southern Province, Zambia', 'page_Speaker of the National Assembly of Zambia', 'page_Stand and Sing of Zambia, Proud and Free', 'page_Tonga language (Zambia)', 'page_Vice President of Zambia', 'page_Vice-President of Zambia', 'page_Western Province, Zambia', 'page_Zambia', 'page_Zambia National Service', 'page_Zambia at the Olympics', 'page_Zambia national basketball team', 'page_Zambia national football team', 'page_Zambia national futsal team', 'page_Zambia national netball team', 'page_Zambia national rugby union team', 'page_Zambia national under-20 football team', \"page_Zambia women's national basketball team\", \"page_Zambia women's national football team\", \"page_Zambia women's national under-17 football team\"]\n"
           ]
         }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **4. Modeling**\n",
+        "We build a decision tree classifier to identify whether a Wikipedia edit was performed by a bot. Decision trees are interpretable and handle mixed feature types without requiring feature scaling.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.tree import DecisionTreeClassifier\n",
+        "from sklearn.metrics import classification_report, accuracy_score\n",
+        "\n",
+        "# Separate features and target\n",
+        "X = df_prepared.drop(columns=['is_bot_edit', 'comment', 'timestamp'])\n",
+        "y = df_prepared['is_bot_edit']\n",
+        "\n",
+        "# Split the data\n",
+        "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+        "\n",
+        "# Train the model\n",
+        "model = DecisionTreeClassifier(random_state=42)\n",
+        "model.fit(X_train, y_train)\n",
+        "\n",
+        "# Evaluate\n",
+        "y_pred = model.predict(X_test)\n",
+        "print(\"Accuracy:\", accuracy_score(y_test, y_pred))\n",
+        "print(classification_report(y_test, y_pred))\n"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add 4. Modeling section to notebook
- split dataset and train a decision tree model to detect bot edits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b58ee51ee0832385ef76c1f38d9b74