### PR TITLE
Ensure non-numeric columns are excluded before model training

### DIFF
--- a/data_mining_project.ipynb
+++ b/data_mining_project.ipynb
@@ -64,7 +64,7 @@
         "- Lessons that could be shared with Wikimedia communities and policymakers incase of encouraging locals to contribute.\n",
         "\n",
         "### Data Mining Goals\n",
-        "- Create a prediction model that can determine the most likely country of origin for each Wikipedia edit made to Zambian pages, using details like the user\u2019s IP address (for anonymous edits), profile information, and the timing of edits.\n",
+        "- Create a prediction model that can determine the most likely country of origin for each Wikipedia edit made to Zambian pages, using details like the user’s IP address (for anonymous edits), profile information, and the timing of edits.\n",
         "\n",
         "- Analyze and visualize the data to show clear summaries of how contributions are distributed by country.\n",
         "\n",
@@ -509,7 +509,7 @@
     {
       "cell_type": "code",
       "source": [
-        "# [DU] Lawrence \u2014 Dataset Info and Descriptive Statistics\n",
+        "# [DU] Lawrence — Dataset Info and Descriptive Statistics\n",
         "\n",
         "# Show dataset structure\n",
         "df.info()\n",
@@ -1289,7 +1289,7 @@
     {
       "cell_type": "code",
       "source": [
-        " # Drop the empty 'contributor_ip' and \u2018contributor_id\u2019 columns\n",
+        " # Drop the empty 'contributor_ip' and ‘contributor_id’ columns\n",
         " df.drop(columns=['contributor_ip'], inplace=True)\n",
         " df.drop(columns=['contributor_id'], inplace=True)\n",
         " # Fill missing values in the 'comment' column with an empty string\n",
@@ -1458,7 +1458,7 @@
             "                                              comment\n",
             "6                 Robot: Adding [[African countries]]\n",
             "9   robot  Adding: am, az, bs, el, fa, ilo, ka, ku...\n",
-            "10                       robot  Adding: [[vo:Samb\u00e4n]]\n",
+            "10                       robot  Adding: [[vo:Sambän]]\n",
             "11       robot  Adding: [[ast:Zambia]], [[qu:Sambya]]\n",
             "12                   robot  Modifying: [[qu:Sambiya]]\n"
           ]
@@ -1682,6 +1682,7 @@
         "\n",
         "# Separate features and target\n",
         "X = df_prepared.drop(columns=['is_bot_edit', 'comment', 'timestamp'])\n",
+        "X = X.select_dtypes(include=\\\"number\\\")\\n",
         "y = df_prepared['is_bot_edit']\n",
         "\n",
         "# Split the data\n",


### PR DESCRIPTION
## Summary
- Drop non-numeric features before fitting the decision tree to avoid conversion errors

## Testing
- `python -m json.tool data_mining_project.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68b5934439f08323a39474dbcc1892b2